### PR TITLE
Fixes & improvements to records page

### DIFF
--- a/src/components/SingleName/ResolverAndRecords/AddRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/AddRecord.js
@@ -335,7 +335,7 @@ function Editable({
         {t('singleName.record.title')}
         {editing ? (
           <ToggleAddRecord onClick={stopEditing}>
-            Close Add/Edit Record
+            Cancel Add/Edit Record
           </ToggleAddRecord>
         ) : (
           <ToggleAddRecord onClick={startEditing}>


### PR DESCRIPTION
This PR fixes some bugs that makes the records page a bit more usable:

* The text records section (vnd.github, urls ... etc) in the ens app shows wrong records (from previously displayed names) because the cache isn't getting updated when searching for a different domain that doesn't have records in that section.
* It's not possible to undo changes without refreshing the page. 
* The comparison of key/value records doesn't work because the updatedRecords object is slightly different so even when undoing a change it still tries to include it in the transaction.
* Uncommitted changes are not cleared when clicking cancel button (requires page refresh)
* Wait for DNS records to load properly