### PR TITLE
Add TLSA record support

### DIFF
--- a/src/components/SingleName/ResolverAndRecords/Records.js
+++ b/src/components/SingleName/ResolverAndRecords/Records.js
@@ -87,8 +87,6 @@ const TEXT_PLACEHOLDER_RECORDS = [
   'notice'
 ]
 
-const DNS_PLACEHOLDER_RECORDS = ['A', 'CNAME', 'TXT']
-
 const COIN_PLACEHOLDER_RECORDS = ['ETH', ...COIN_LIST.slice(0, 3)]
 
 function isEmpty(record) {
@@ -311,8 +309,8 @@ export default function Records({
         : processRecords([], TEXT_PLACEHOLDER_RECORDS),
     dnsRecords:
       dataDnsRecords && dataDnsRecords.getDNSRecords
-        ? processRecords(dataDnsRecords.getDNSRecords, DNS_PLACEHOLDER_RECORDS)
-        : processRecords([], DNS_PLACEHOLDER_RECORDS),
+        ? processRecords(dataDnsRecords.getDNSRecords, DNS_RECORD_KEYS)
+        : processRecords([], DNS_RECORD_KEYS),
     coins:
       dataAddresses && dataAddresses.getAddresses
         ? processRecords(dataAddresses.getAddresses, COIN_PLACEHOLDER_RECORDS)
@@ -449,7 +447,7 @@ export default function Records({
         loading={dnsRecordsLoading}
         title={t('c.dnsrecord')}
         updatedRecords={updatedRecords}
-        placeholderRecords={DNS_PLACEHOLDER_RECORDS}
+        placeholderRecords={DNS_RECORD_KEYS}
         setUpdatedRecords={setUpdatedRecords}
         changedRecords={changedRecords}
       />

--- a/src/constants/dnsRecords.json
+++ b/src/constants/dnsRecords.json
@@ -1,1 +1,1 @@
-["A", "CNAME", "TXT"]
+["A", "CNAME", "TXT", "TLSA (443, tcp)"]

--- a/src/utils/dns.js
+++ b/src/utils/dns.js
@@ -13,9 +13,22 @@ export function normalizeTXT(txt) {
   return txt
 }
 
-export function strRecord(name, ttl, type, value) {
+export function serializeRecord(name, ttl, type, value) {
+  name = bns.util.fqdn(name)
+
   if (type === 'TXT' && value !== '') value = normalizeTXT(value)
   if (type === 'CNAME' && value !== '') value = bns.util.fqdn(value)
+  const dns = toDNSName(name, type)
 
-  return name + ' ' + ttl + ' IN ' + type + ' ' + value
+  return dns.name + ' ' + ttl + ' IN ' + dns.type + ' ' + value
+}
+
+export function toDNSName(node, type) {
+  let name = node
+  if (type === 'TLSA (443, tcp)') {
+    type = 'TLSA'
+    name = '_443._tcp.' + name
+  }
+
+  return { node, name, type }
 }

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -1,13 +1,13 @@
 import { encodeContenthash, isValidContenthash } from '@ensdomains/ui'
 import { addressUtils } from 'utils/utils'
-import { normalizeTXT, strRecord } from './dns'
+import { normalizeTXT, serializeRecord } from './dns'
 import { formatsByName } from '@ensdomains/address-encoder'
 import bns from 'bns'
 
 export function validateDNSInput(type, value) {
   if (value === '') return true
 
-  const record = strRecord('example.eth.', '0', type, value)
+  const record = serializeRecord('example.eth.', '0', type, value)
   try {
     bns.wire.Record.fromString(record)
     return true


### PR DESCRIPTION
This PR allows adding a basic TLSA record for port 443 to support HTTPS. It adds the record `_443._tcp.<domain name>` to the zone. 

<img src='https://user-images.githubusercontent.com/41967894/121901095-f5943600-ccda-11eb-8678-3ff15ac69574.png' width='500px' />

Due to how EIP-1185 works, it's not possible to allow adding a TLSA with arbitrary ports and protos because `dnsRecord` requires knowing the exact record name to display it back in the UI (at least by using the contract directly), but such advanced options aren't needed for most users right now. 