### PR TITLE
Hide subdomains tab and routes

### DIFF
--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -701,21 +701,21 @@ function NameDetails({
         }}
       />
 
-      <Route
-        exact
-        path="/name/:name/subdomains"
-        render={() => (
-          <SubDomains
-            domain={domain}
-            isOwner={isOwner}
-            data-testid="subdomains"
-            isMigratedToNewRegistry={isMigratedToNewRegistry}
-            loadingIsMigrated={loadingIsMigrated}
-            isParentMigratedToNewRegistry={isParentMigratedToNewRegistry}
-            loadingIsParentMigrated={loadingIsParentMigrated}
-          />
-        )}
-      />
+      {/*<Route*/}
+      {/*  exact*/}
+      {/*  path="/name/:name/subdomains"*/}
+      {/*  render={() => (*/}
+      {/*    <SubDomains*/}
+      {/*      domain={domain}*/}
+      {/*      isOwner={isOwner}*/}
+      {/*      data-testid="subdomains"*/}
+      {/*      isMigratedToNewRegistry={isMigratedToNewRegistry}*/}
+      {/*      loadingIsMigrated={loadingIsMigrated}*/}
+      {/*      isParentMigratedToNewRegistry={isParentMigratedToNewRegistry}*/}
+      {/*      loadingIsParentMigrated={loadingIsParentMigrated}*/}
+      {/*    />*/}
+      {/*  )}*/}
+      {/*/>*/}
 
       <Route
         exact

--- a/src/components/SingleName/Tabs.js
+++ b/src/components/SingleName/Tabs.js
@@ -82,12 +82,12 @@ const Tabs = ({ domain, pathname, parent, tab }) => {
         >
           {t('singleName.tabs.details')}
         </TabLink>
-        <TabLink
-          active={pathname === `/name/${name}/subdomains`}
-          to={`/name/${name}/subdomains`}
-        >
-          {t('singleName.tabs.subdomains')}
-        </TabLink>
+        {/*<TabLink*/}
+        {/*  active={pathname === `/name/${name}/subdomains`}*/}
+        {/*  to={`/name/${name}/subdomains`}*/}
+        {/*>*/}
+        {/*  {t('singleName.tabs.subdomains')}*/}
+        {/*</TabLink>*/}
       </TabContainer>
     )
   )


### PR DESCRIPTION
This hides the subdomains tab and the route `/name/:name/subdomains` until we remove it completely or support it 